### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/abaldeweg/services/security/code-scanning/1](https://github.com/abaldeweg/services/security/code-scanning/1)

To address the issue, add a `permissions` block to the root of the workflow file. This block will explicitly limit the `GITHUB_TOKEN` permissions to the least privileges required. In this case, the workflow only requires access to the code repository for tasks like checking out the code; therefore, `contents: read` is sufficient. This fix ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
